### PR TITLE
Added prototype for clock "macro" file emission

### DIFF
--- a/src/addons/core-generator/rocket-chip/rules.mk
+++ b/src/addons/core-generator/rocket-chip/rules.mk
@@ -40,11 +40,11 @@ $(OBJ_CORE_DIR)/plsi-generated/model.vh:
 
 $(OBJ_CORE_DIR)/plsi-generated/$(CORE_SIM_TOP).$(CORE_CONFIG).v: $(OBJ_CORE_FIRRTL_HARNESS_CMD) $(RC_OBJ_CORE_RTL_FIR)
 	@mkdir -p $(dir $@)
-	$(SCHEDULER_CMD) --max-threads=1 -- $< -i $(abspath $(filter %.fir,$^)) -o $(abspath $@) --syn-top $(CORE_TOP) --harness-top $(CORE_SIM_TOP)
+	$(SCHEDULER_CMD) --max-threads=1 -- $< -i $(abspath $(filter %.fir,$^)) -o $(abspath $@) --syn-top $(CORE_TOP) --macro-output $(basename $(abspath $@))$(MACRO) --harness-top $(CORE_SIM_TOP)
 
 $(RC_OBJ_CORE_RTL_V): $(OBJ_CORE_FIRRTL_TOP_CMD) $(RC_OBJ_CORE_RTL_FIR)
 	@mkdir -p $(dir $@)
-	$(SCHEDULER_CMD) --max-threads=1 -- $< -i $(abspath $(filter %.fir,$^)) -o $(abspath $@) --syn-top $(CORE_TOP) --harness-top $(CORE_SIM_TOP)
+	$(SCHEDULER_CMD) --max-threads=1 -- $< -i $(abspath $(filter %.fir,$^)) -o $(abspath $@) --syn-top $(CORE_TOP) --macro-output $(basename $(abspath $@))$(MACRO) --harness-top $(CORE_SIM_TOP)
 
 $(RC_OBJ_CORE_RTL_FIR) $(RC_OBJ_CORE_RTL_D): $(OBJ_CORE_DIR)/plsi-generated/$(CORE_SIM_TOP).$(CORE_CONFIG).vsim.stamp
 	mkdir -p $(dir $@)

--- a/src/addons/core-generator/rocket-chip/src/firrtl/project/build.scala
+++ b/src/addons/core-generator/rocket-chip/src/firrtl/project/build.scala
@@ -13,7 +13,8 @@ object BuildSettings extends Build {
     parallelExecution in Global := false,
     traceLevel   := 15,
     scalacOptions ++= Seq("-deprecation","-unchecked"),
-    libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
+    libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value),
+    libraryDependencies ++= Seq("io.spray" %%  "spray-json" % "1.3.2")
   )
 
   lazy val firrtl       = project in file("firrtl")

--- a/src/addons/core-generator/rocket-chip/src/firrtl/src/main/scala/CollectClocks.scala
+++ b/src/addons/core-generator/rocket-chip/src/firrtl/src/main/scala/CollectClocks.scala
@@ -1,0 +1,39 @@
+// See LICENSE for license details.
+
+// Firrtl imports
+import firrtl._
+import firrtl.ir._
+import firrtl.passes.Pass
+
+// Scala imports
+import scala.collection.mutable
+//import java.io.Writer
+
+// JSON serialization
+import spray.json._
+import DefaultJsonProtocol._
+
+// Collects clock-typed ports that are either:
+//   1) input to top level module
+//   2) output to any module
+class CollectClocks(macroTop: String) extends Pass {
+  def name = "Collect Clocks"
+
+  def run(c: Circuit): Circuit = {
+    val clocks = mutable.HashSet[String]() //ModuleName.ClockName
+    def addPorts(d: Direction)(p: Port): Unit = p match {
+      case Port(info, name, dir, ClockType) if dir == d => clocks += name
+      case _ =>
+    }
+    def onModule(m: DefModule): DefModule = {
+      if(m.name == c.main) m.ports foreach addPorts(Input)
+      m.ports foreach addPorts(Output)
+      m
+    }
+    val outputFile = new java.io.PrintWriter(macroTop)
+    c.copy(modules=c.modules map onModule)
+    outputFile.write(clocks.toSeq.toJson.prettyPrint)
+    outputFile.close()
+    c
+  }
+}

--- a/src/addons/core-generator/rocket-chip/vars.mk
+++ b/src/addons/core-generator/rocket-chip/vars.mk
@@ -10,6 +10,9 @@ CORE_TOP ?= $(RC_CORE_TOP)
 RC_CORE_SIM_TOP = TestHarness
 CORE_SIM_TOP ?= $(RC_CORE_SIM_TOP)
 
+RC_MACRO = ExampleMacro.macro
+MACRO ?= $(RC_MACRO)
+
 # This contains the whole Rocket Chip along with all the test harness stuff.
 RC_OBJ_CORE_RTL_V = $(OBJ_CORE_DIR)/plsi-generated/$(CORE_TOP).$(CORE_CONFIG).v
 OBJ_CORE_RTL_V ?= $(RC_OBJ_CORE_RTL_V)


### PR DESCRIPTION
Unfinished, do not merge.

I've sketched out what the Firrtl pass may look like. There is a lot more makefile hacking that needs to be done to make everything work.

There isn't a good way to detect a "clock" signal per se, because a PLL/clock divider will be a blackbox with a clock input and multiple clock outputs. My assumption is that I should annotate the top module's input clock, as well as any clock signals that are module outputs.

@palmer-dabbelt Any comments?