### PR TITLE
unset DISPLAY in dc run-synthesis

### DIFF
--- a/src/addons/synthesis/dc/tools/run-synthesis
+++ b/src/addons/synthesis/dc/tools/run-synthesis
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+unset DISPLAY
 unset run_dir
 unset dc
 unset rmtar


### PR DESCRIPTION
At the end of synthesis, dc tries to open a GUI that I don't have a license
for. Unsetting DISPLAY stops this from happening.