### PR TITLE
Formality

### DIFF
--- a/src/addons/formal/formality/run-formality
+++ b/src/addons/formal/formality/run-formality
@@ -25,6 +25,14 @@ sed 's/\(\s*\)#\(\s*\)\(set_app_var hdlin_unresolved_modules black_box\)/\3/' -i
 # FIXME: This appears to come from FIRRTL
 sed '/^set_app_var hdlin_unresolved_modules black_box/a set_mismatch_message_filter -suppress FMR_ELAB-147' -i generated-scripts/verify.tcl
 
+# Report matching points
+sed '/^match/a report_matched_points -point_type reg > '$dc_dir'/reports/${DESIGN_NAME}.fmv_matched_points.rpt\
+report_matched_points -point_type port >> '$dc_dir'/reports/${DESIGN_NAME}.fmv_matched_points.rpt\
+report_matched_points -point_type block_pin >> '$dc_dir'/reports/${DESIGN_NAME}.fmv_matched_points.rpt\
+report_matched_points -point_type bbox >> '$dc_dir'/reports/${DESIGN_NAME}.fmv_matched_points.rpt\
+report_matched_points -point_type bbox_pin >> '$dc_dir'/reports/${DESIGN_NAME}.fmv_matched_points.rpt\
+' -i generated-scripts/verify.tcl
+
 # Run Formality
 cat /dev/null | $formality -f $dc_dir/generated-scripts/verify.tcl
 

--- a/src/addons/formal/formality/run-formality
+++ b/src/addons/formal/formality/run-formality
@@ -4,11 +4,15 @@ set -ex
 
 unset dc_dir
 unset formality
+unset no_verify
+
+no_verify=false
 
 while [[ "$1" != "" ]]
 do
     case "$1" in
     --dc-dir) dc_dir="$2"; shift;;
+    --no-verify) no_verify=true;;
     */fm_shell) formality="$1";;
     *) echo "Unknown argument $1"; exit 1;;
     esac
@@ -32,6 +36,11 @@ report_matched_points -point_type block_pin >> '$dc_dir'/reports/${DESIGN_NAME}.
 report_matched_points -point_type bbox >> '$dc_dir'/reports/${DESIGN_NAME}.fmv_matched_points.rpt\
 report_matched_points -point_type bbox_pin >> '$dc_dir'/reports/${DESIGN_NAME}.fmv_matched_points.rpt\
 ' -i generated-scripts/verify.tcl
+
+# Optionally run verify
+if $no_verify; then
+  sed 's/\!\[verify\]/0/' -i generated-scripts/verify.tcl
+fi
 
 # Run Formality
 cat /dev/null | $formality -f $dc_dir/generated-scripts/verify.tcl

--- a/src/addons/formal/formality/run-formality
+++ b/src/addons/formal/formality/run-formality
@@ -2,81 +2,30 @@
 
 set -ex
 
-verilog=()
-db=()
-reference_verilog=()
-implementation_verilog=()
-reference_top=()
-implementation_top=()
-formality=()
+unset dc_dir
+unset formality
+
 while [[ "$1" != "" ]]
 do
     case "$1" in
-    --reference-verilog) reference_verilog+=("$2"); shift;;
-    --implementation-verilog) implementation_verilog+=("$2"); shift;;
-    --reference-top) reference_top+=("$2"); shift;;
-    --implementation-top) implementation_top+=("$2"); shift;;
-    */fm_shell) formality+=("$1");;
-    *.v) verilog+=("$1");;
-    *.db) db+=("$1");;
+    --dc-dir) dc_dir="$2"; shift;;
+    */fm_shell) formality="$1";;
     *) echo "Unknown argument $1"; exit 1;;
     esac
     shift
 done
 
-tempdir=$(mktemp -d /tmp/plsi-formality.XXXXXX)
-trap "rm -rf $tempdir" EXIT
-
-cd $tempdir
-
-# Generic options to control Formality's behavior
-cat >verify.tcl <<EOF
-# Synopsys' recommended settings
-set synopsys_auto_setup true
-
-# FIXME: This appears to come from FIRRTL
-set_mismatch_message_filter -suppress FMR_ELAB-147
+# Use the Sysnopsys's Formality script
+cd $dc_dir
+cp rm_dc_scripts/fm.tcl generated-scripts/verify.tcl
 
 # FIXME: The Synopsys 32nm EDK seems to have some missing references, this
 # ignores them.
-set hdlin_unresolved_modules black_box
-EOF
+sed 's/\(\s*\)#\(\s*\)\(set_app_var hdlin_unresolved_modules black_box\)/\3/' -i generated-scripts/verify.tcl
+# FIXME: This appears to come from FIRRTL
+sed '/^set_app_var hdlin_unresolved_modules black_box/a set_mismatch_message_filter -suppress FMR_ELAB-147' -i generated-scripts/verify.tcl
 
-# Reference Design
-for v in ${reference_verilog[*]} ${verilog[*]}
-do
-    echo "read_verilog -r $v" >> verify.tcl
-done
-
-cat >>verify.tcl <<EOF
-set_top ${reference_top}
-set_reference r:/WORK/${reference_top}
-EOF
-
-# Implementation Design
-for v in ${implementation_verilog[*]} ${verilog[*]}
-do
-    echo "read_verilog -i $v" >> verify.tcl
-done
-
-for db in ${db[*]}
-do
-    echo "read_db -i $db" >> verify.tcl
-done
-
-cat >>verify.tcl <<EOF
-set_top ${implementation_top}
-set_implementation i:/WORK/${implementation_top}
-EOF
-
-# Verification
-cat >>verify.tcl <<EOF
-verify
-quit
-EOF
-
-cat verify.tcl
-
-cat /dev/null | ${formality[*]} -f verify.tcl
+# Run Formality
+cat /dev/null | $formality -f $dc_dir/generated-scripts/verify.tcl
 
 exit 1

--- a/src/addons/formal/formality/syn-rules.mk
+++ b/src/addons/formal/formality/syn-rules.mk
@@ -9,4 +9,4 @@ $(CHECK_SYN_DIR)/formality-$(MAP_TOP)-$(SYN_TOP).out: \
 		$(TECHNOLOGY_VERILOG_FILES) \
 		$(TECHNOLOGY_CCS_LIBRARY_FILES)
 	mkdir -p $(dir $@)
-	$(SCHEDULER_CMD) -- $(CMD_PTEST) --test $(abspath $<) --out $(abspath $@) --args --reference-verilog $(abspath $(OBJ_MAP_RTL_V)) --implementation-verilog $(abspath $(OBJ_SYN_MAPPED_V)) --reference-top $(MAP_TOP) --implementation-top $(SYN_TOP) $(abspath $(FORMALITY_BIN)) $(abspath $(TECHNOLOGY_VERILOG_FILES)) $(abspath $(TECHNOLOGY_CCS_LIBRARY_FILES))
+	$(SCHEDULER_CMD) -- $(CMD_PTEST) --test $(abspath $<) --out $(abspath $@) --args $(abspath $(FORMALITY_BIN)) --dc-dir $(abspath $(OBJ_SYN_DIR)/synopsys-dc-workdir)

--- a/src/addons/formal/formality/syn-rules.mk
+++ b/src/addons/formal/formality/syn-rules.mk
@@ -9,4 +9,4 @@ $(CHECK_SYN_DIR)/formality-$(MAP_TOP)-$(SYN_TOP).out: \
 		$(TECHNOLOGY_VERILOG_FILES) \
 		$(TECHNOLOGY_CCS_LIBRARY_FILES)
 	mkdir -p $(dir $@)
-	$(SCHEDULER_CMD) -- $(CMD_PTEST) --test $(abspath $<) --out $(abspath $@) --args $(abspath $(FORMALITY_BIN)) --dc-dir $(abspath $(OBJ_SYN_DIR)/synopsys-dc-workdir)
+	$(SCHEDULER_CMD) -- $(CMD_PTEST) --test $(abspath $<) --out $(abspath $@) --args $(abspath $(FORMALITY_BIN)) --dc-dir $(abspath $(OBJ_SYN_DIR)/synopsys-dc-workdir) $(if $(FORMALITY_NO_VERIFY),--no-verify)

--- a/src/addons/formal/formality/syn-vars.mk
+++ b/src/addons/formal/formality/syn-vars.mk
@@ -14,3 +14,7 @@ FORMALITY_BIN = $(FORMALITY_HOME)/bin/fm_shell
 ifeq ($(wildcard $(FORMALITY_BIN)),)
 $(error Cannot find formality at $(FORMALITY_BIN))
 endif
+
+ifneq ($(SYNTHESIS_TOOL),dc)
+$(error Formality needs to run with SYNTHESIS_TOOL=dc)
+endif


### PR DESCRIPTION
We can just use the Synopsys's Formality script to run it. I also make it report matching points and optionally run verify for strober. Now, rocket-chip passes formality with saed32.